### PR TITLE
fix(rspack/express): fix the build command

### DIFF
--- a/rspack/express/package.json
+++ b/rspack/express/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "rspack serve",
-    "build": "rspack build"
+    "build": "cross-env BUILD=true rspack build"
   },
   "devDependencies": {
     "@rspack/cli": "latest",


### PR DESCRIPTION
It was throwing an error

> rspack build

Rspack compiled successfully in 94 ms
/Users/bytedance/github/rspack-examples/rspack/express/dist/main.js:15276 } else throw new Error("[HMR] Hot Module Replacement is disabled.");
       ^

Error: [HMR] Hot Module Replacement is disabled.
    at 5302 (/Users/bytedance/github/rspack-examples/rspack/express/dist/main.js:15276:14)