### PR TITLE
chore: add swc helpers alias in monorepo

### DIFF
--- a/libs/lib3/package.json
+++ b/libs/lib3/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "lib3",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/libs/lib3/src/index.js
+++ b/libs/lib3/src/index.js
@@ -1,0 +1,3 @@
+export async function answer() {
+  return 42;
+}

--- a/rspack/builtin-swc-loader/package.json
+++ b/rspack/builtin-swc-loader/package.json
@@ -16,7 +16,8 @@
     "@rspack/core": "latest",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-refresh": "0.14.0"
+    "react-refresh": "0.14.0",
+    "lib3": "workspace:*"
   },
   "devDependencies": {
     "@rspack/core": "latest",

--- a/rspack/builtin-swc-loader/rspack.config.js
+++ b/rspack/builtin-swc-loader/rspack.config.js
@@ -1,55 +1,62 @@
 const rspack = require("@rspack/core");
+const path = require("path");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
-	entry: {
-		main: "./src/index.jsx"
-	},
-	resolve: {
-		extensions: ["...", ".jsx"]
-	},
-	module: {
-		rules: [
-			{
-				test: /\.jsx$/,
-				use: {
-					loader: "builtin:swc-loader",
-					options: {
-						// Enable source map
-						sourceMap: true,
-						jsc: {
-							parser: {
-								syntax: "ecmascript",
-								jsx: true
-							},
-							externalHelpers: true,
-							preserveAllComments: false,
-							transform: {
-								react: {
-									runtime: "automatic",
-									pragma: "React.createElement",
-									pragmaFrag: "React.Fragment",
-									throwIfNamespace: true,
-									useBuiltins: false
-								}
-							}
-						}
-					}
-				},
-				type: "javascript/auto"
-			},
-			{
-				test: /\.(png|svg|jpg)$/,
-				type: "asset/resource"
-			}
-		]
-	},
-	optimization: {
-		minimize: false // Disabling minification because it takes too long on CI
-	},
-	plugins: [
-		new rspack.HtmlRspackPlugin({
-			template: "./index.html"
-		})
-	]
+  entry: {
+    main: "./src/index.jsx",
+  },
+  resolve: {
+    extensions: ["...", ".jsx"],
+    alias: {
+      "@swc/helpers": path.dirname(
+        require.resolve("@swc/helpers/package.json")
+      ),
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(jsx|js)$/,
+        use: {
+          loader: "builtin:swc-loader",
+          options: {
+            // Enable source map
+            sourceMap: true,
+            target: "es5",
+            jsc: {
+              parser: {
+                syntax: "ecmascript",
+                jsx: true,
+              },
+              externalHelpers: true,
+              preserveAllComments: false,
+              transform: {
+                react: {
+                  runtime: "automatic",
+                  pragma: "React.createElement",
+                  pragmaFrag: "React.Fragment",
+                  throwIfNamespace: true,
+                  useBuiltins: false,
+                },
+              },
+            },
+          },
+        },
+        type: "javascript/auto",
+      },
+      {
+        test: /\.(png|svg|jpg)$/,
+        type: "asset/resource",
+      },
+    ],
+  },
+  optimization: {
+    minimize: false, // Disabling minification because it takes too long on CI
+  },
+  plugins: [
+    new rspack.HtmlRspackPlugin({
+      template: "./index.html",
+    }),
+  ],
 };
 module.exports = config;

--- a/rspack/builtin-swc-loader/src/index.jsx
+++ b/rspack/builtin-swc-loader/src/index.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import {answer} from 'lib3';
+console.log('answer:',answer());
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/rspack/nest-alias/rspack.config.js
+++ b/rspack/nest-alias/rspack.config.js
@@ -1,18 +1,13 @@
-const {defineConfig } = require('@rspack/cli');
-const path = require('path');
+const { defineConfig } = require("@rspack/cli");
+const path = require("path");
 module.exports = defineConfig({
   entry: {
-    main: './src/index.ts',
-  },
-  experiments: {
-    rspackFuture: {
-      newResolver:true
-    }
+    main: "./src/index.ts",
   },
   resolve: {
     tsConfig: {
-      references: 'auto',
-      configFile:path.resolve(__dirname,'./tsconfig.json')
-    }
-  }
+      references: "auto",
+      configFile: path.resolve(__dirname, "./tsconfig.json"),
+    },
+  },
 });


### PR DESCRIPTION
builtin:swc-loader will inject @swc/helpers into transformed code which will cause phantom deps, so it would better to configure alias for @swc/helpers for monorepo