### PR TITLE
feat: add treeshaking transform imports example

### DIFF
--- a/rspack/treeshaking-transform-imports/package.json
+++ b/rspack/treeshaking-transform-imports/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-treeshaking-transform-imports",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "latest",
+    "@rspack/core": "latest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/rspack/treeshaking-transform-imports/rspack.config.js
+++ b/rspack/treeshaking-transform-imports/rspack.config.js
@@ -1,0 +1,18 @@
+const rspack = require("@rspack/core");
+/** @type {import('@rspack/core').Configuration} */
+const config = {
+	context: __dirname,
+	entry: {
+		main: "./src/index.js"
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin()
+	],
+	optimization: {
+		minimize: false,
+		moduleIds: 'named',
+		providedExports: true,
+		sideEffects: true,
+	}
+};
+module.exports = config;

--- a/rspack/treeshaking-transform-imports/src/a.js
+++ b/rspack/treeshaking-transform-imports/src/a.js
@@ -1,0 +1,2 @@
+import { b } from './sdk'
+export const a = b;

--- a/rspack/treeshaking-transform-imports/src/b.js
+++ b/rspack/treeshaking-transform-imports/src/b.js
@@ -1,0 +1,1 @@
+export const b = 1;

--- a/rspack/treeshaking-transform-imports/src/c.js
+++ b/rspack/treeshaking-transform-imports/src/c.js
@@ -1,0 +1,1 @@
+export const c = 1;

--- a/rspack/treeshaking-transform-imports/src/index.js
+++ b/rspack/treeshaking-transform-imports/src/index.js
@@ -1,0 +1,2 @@
+import { a } from './sdk';
+console.log(a);

--- a/rspack/treeshaking-transform-imports/src/sdk.js
+++ b/rspack/treeshaking-transform-imports/src/sdk.js
@@ -1,0 +1,3 @@
+export { a } from './a'
+export { b } from './b'
+export { c } from './c'


### PR DESCRIPTION
This example shows how `optimization.sideEffects` transforms imports, and how to solve the circular dependencies issue