### PR TITLE
feat: add rsbuild with express example

### DIFF
--- a/rsbuild/express/.gitignore
+++ b/rsbuild/express/.gitignore
@@ -1,0 +1,13 @@
+# Local
+.DS_Store
+*.local
+*.log*
+
+# Dist
+node_modules
+dist/
+
+# IDE
+.vscode/*
+!.vscode/extensions.json
+.idea

--- a/rsbuild/express/README.md
+++ b/rsbuild/express/README.md
@@ -1,0 +1,29 @@
+# Rsbuild Project
+
+## Setup
+
+Install the dependencies:
+
+```bash
+pnpm install
+```
+
+## Get Started
+
+Start the dev server:
+
+```bash
+pnpm dev
+```
+
+Build the app for production:
+
+```bash
+pnpm build
+```
+
+Preview the production build locally:
+
+```bash
+pnpm preview
+```

--- a/rsbuild/express/package.json
+++ b/rsbuild/express/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rsbuild-express",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "node ./server.mjs",
+    "build": "rsbuild build",
+    "preview": "rsbuild preview"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "^0.6.0",
+    "express": "^4.18.3",
+    "typescript": "^5.3.0",
+    "@types/express": "^4.17.21"
+  }
+}

--- a/rsbuild/express/rsbuild.config.mjs
+++ b/rsbuild/express/rsbuild.config.mjs
@@ -1,0 +1,3 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({});

--- a/rsbuild/express/server.mjs
+++ b/rsbuild/express/server.mjs
@@ -1,0 +1,38 @@
+import express from 'express';
+import { createRsbuild } from '@rsbuild/core';
+import { loadConfig } from '@rsbuild/core';
+
+
+export async function startDevServer() {
+  const { content } = await loadConfig({});
+
+  // Init Rsbuild
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: content,
+  });
+
+  const app = express();
+
+  // Create Rsbuild DevServer instance
+  const rsbuildServer = await rsbuild.createDevServer();
+
+  // Apply Rsbuild’s built-in middlewares
+  app.use(rsbuildServer.middlewares);
+
+  const httpServer = app.listen(rsbuildServer.port, async () => {
+    // Notify Rsbuild that the custom server has started
+    await rsbuildServer.afterListen();
+  });
+
+// Subscribe to the server's http upgrade event to handle WebSocket upgrades
+  httpServer.on('upgrade', rsbuildServer.onHTTPUpgrade);
+
+  return {
+    close: async () => {
+      await rsbuildServer.close();
+      httpServer.close();
+    },
+  };
+}
+
+startDevServer(process.cwd());

--- a/rsbuild/express/src/index.css
+++ b/rsbuild/express/src/index.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/rsbuild/express/src/index.js
+++ b/rsbuild/express/src/index.js
@@ -1,0 +1,8 @@
+import './index.css';
+
+document.querySelector('#root').innerHTML = `
+<div class="content">
+  <h1>Rsbuild with Express</h1>
+  <p>Start building amazing things with Rsbuild.</p>
+</div>
+`;


### PR DESCRIPTION
Rsbuild's createDevServer method can be used to integrate the Rsbuild dev-server into a custom server.

https://rsbuild.dev/api/javascript-api/instance#rsbuildcreatedevserver
