### PR TITLE
chore: enable rspack build in rspack/vanilla-extract-css

### DIFF
--- a/rspack/vanilla-extract-css/package.json
+++ b/rspack/vanilla-extract-css/package.json
@@ -9,7 +9,7 @@
     "webpack:start": "webpack serve",
     "webpack:build": "webpack",
     "start": "rspack serve",
-    "build": "echo success"
+    "build": "rspack build"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Closes #5

That error is related to nmf hooks that has been shipped in 0.6.x.

So it now works.

![image](https://github.com/rspack-contrib/rspack-examples/assets/18117084/5f3062f2-30a5-4a02-96af-b7beb846dd40)
