### PR TITLE
feat: use @swc/plugin-emotion

### DIFF
--- a/rsbuild/emotion/package.json
+++ b/rsbuild/emotion/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@rsbuild/core": "^0.7.0",
     "@rsbuild/plugin-react": "^0.7.0",
+    "@swc/plugin-emotion": "^3.0.5",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.3.0"

--- a/rsbuild/emotion/rsbuild.config.ts
+++ b/rsbuild/emotion/rsbuild.config.ts
@@ -11,8 +11,10 @@ export default defineConfig({
   ],
   tools: {
     swc: {
-      rspackExperiments: {
-        emotion: true,
+      jsc: {
+        experimental: {
+          plugins: [['@swc/plugin-emotion', {}]],
+        },
       },
     },
   },

--- a/rspack/emotion/package.json
+++ b/rspack/emotion/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "^0.7.0",
-    "@rspack/core": "^0.7.0"
+    "@rspack/core": "^0.7.0",
+    "@swc/plugin-emotion": "^3.0.5"
   }
 }

--- a/rspack/emotion/rspack.config.js
+++ b/rspack/emotion/rspack.config.js
@@ -32,9 +32,9 @@ const config = {
                 runtime: 'automatic',
               },
             },
-          },
-          rspackExperiments: {
-            emotion: true,
+            experimental: {
+              plugins: [['@swc/plugin-emotion', {}]],
+            },
           },
         },
         type: 'javascript/auto',


### PR DESCRIPTION
Use `@swc/plugin-emotion` to replace `rspackExperiments.emotion`.