### PR TITLE
fix: rspack 1.0.0-beta.5 ecosystem ci

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,7 +462,7 @@ importers:
         version: 18.2.19
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.1(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.2))
+        version: 3.4.1(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.2))
       typescript:
         specifier: ^5.3.0
         version: 5.4.2
@@ -526,7 +526,7 @@ importers:
         version: 2.3.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)))
+        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)))
     devDependencies:
       '@rsbuild/core':
         specifier: ^1.0.1-beta.9
@@ -545,7 +545,7 @@ importers:
         version: 18.3.0
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.3(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+        version: 3.4.3(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -729,7 +729,7 @@ importers:
         version: 1.0.1-beta.9
       '@rsbuild/plugin-svelte':
         specifier: ^1.0.1-beta.9
-        version: 1.0.1-beta.9(@babel/core@7.24.9)(@rsbuild/core@1.0.1-beta.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3)
+        version: 1.0.1-beta.9(@babel/core@7.24.9)(@rsbuild/core@1.0.1-beta.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3)
       typescript:
         specifier: ^5.3.0
         version: 5.3.3
@@ -788,7 +788,7 @@ importers:
         version: 1.0.1-beta.9
       '@rsbuild/plugin-vue2':
         specifier: ^1.0.1-beta.9
-        version: 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0))
+        version: 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5)(webpack@5.93.0))
       typescript:
         specifier: ^5.3.0
         version: 5.3.3
@@ -1062,13 +1062,13 @@ importers:
     devDependencies:
       '@modern-js/app-tools':
         specifier: 2.48.3
-        version: 2.48.3(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3)))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack-hot-middleware@2.26.1)
+        version: 2.48.3(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0))(webpack-hot-middleware@2.26.1)
       '@modern-js/runtime':
         specifier: 2.48.3
-        version: 2.48.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+        version: 2.48.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(webpack@5.93.0(esbuild@0.17.19))
       '@rsdoctor/rspack-plugin':
         specifier: ^0.3.10
-        version: 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
+        version: 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))
       '@types/node':
         specifier: ^20
         version: 20.12.12
@@ -1080,7 +1080,7 @@ importers:
         version: 18.2.19
       ts-loader:
         specifier: 9.4.2
-        version: 9.4.2(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+        version: 9.4.2(typescript@5.4.5)(webpack@5.93.0(esbuild@0.17.19))
       tslib:
         specifier: 2.4.1
         version: 2.4.1
@@ -1105,10 +1105,10 @@ importers:
     devDependencies:
       '@rsdoctor/cli':
         specifier: ^0.3.10
-        version: 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
+        version: 0.3.10(@rspack/core@0.7.5)
       '@rsdoctor/webpack-plugin':
         specifier: ^0.3.10
-        version: 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11)))
+        version: 0.3.10(@rspack/core@0.7.5)(webpack@5.93.0)
       '@types/node':
         specifier: ^20
         version: 20.12.6
@@ -1126,7 +1126,7 @@ importers:
         version: 8.4.21
       tailwindcss:
         specifier: ^3.3.0
-        version: 3.4.1(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.6)(typescript@5.4.2))
+        version: 3.4.1(ts-node@10.9.2(@types/node@20.12.6)(typescript@5.4.2))
       typescript:
         specifier: ^5
         version: 5.4.2
@@ -1445,6 +1445,8 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
 
+  rspack/generate-package-json-webpack-plugin@2/dist: {}
+
   rspack/html-webpack-plugin:
     devDependencies:
       '@rspack/cli':
@@ -1671,7 +1673,7 @@ importers:
         version: 9.1.3(@babel/core@7.23.9)(webpack@5.93.0(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.5.0
-        version: 5.6.0(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0(webpack-cli@4.10.0))
+        version: 5.6.0(@rspack/core@0.7.5)(webpack@5.93.0(webpack-cli@4.10.0))
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
@@ -2496,7 +2498,7 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: ^1.0.0-beta.1
-        version: 1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11)))
+        version: 1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack@5.93.0)
       '@rspack/core':
         specifier: ^1.0.0-beta.1
         version: 1.0.0-beta.1(@swc/helpers@0.5.11)
@@ -2514,19 +2516,19 @@ importers:
         version: 5.8.0(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))
       postcss-load-config:
         specifier: 4.0.1
-        version: 4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+        version: 4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       svelte:
         specifier: ^3.55.1
         version: 3.59.2
       svelte-check:
         specifier: ^3.0.3
-        version: 3.6.4(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)
+        version: 3.6.4(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)
       svelte-loader:
         specifier: ^3.1.5
         version: 3.1.9(svelte@3.59.2)
       svelte-preprocess:
         specifier: ^5.0.1
-        version: 5.1.3(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)(typescript@5.4.5)
+        version: 5.1.3(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)(typescript@5.4.5)
       tslib:
         specifier: ^2.5.0
         version: 2.6.2
@@ -2581,7 +2583,7 @@ importers:
         version: 7.2.3(@types/node@20.12.12)(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11)))
       tailwindcss:
         specifier: 3.3.1
-        version: 3.3.1(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+        version: 3.3.1(postcss@8.4.21)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
 
   rspack/tailwind-jit:
     devDependencies:
@@ -2602,16 +2604,16 @@ importers:
         version: 7.2.3(@types/node@20.12.12)(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11)))
       tailwindcss:
         specifier: 3.3.1
-        version: 3.3.1(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+        version: 3.3.1(postcss@8.4.21)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
 
   rspack/terser-webpack-plugin:
     devDependencies:
       '@rspack/cli':
-        specifier: 1.0.0-alpha.0
-        version: 1.0.0-alpha.0(@rspack/core@1.0.0-alpha.0(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack@5.93.0)
+        specifier: 1.0.0-beta.5
+        version: 1.0.0-beta.5(@rspack/core@1.0.0-beta.5(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack@5.93.0)
       '@rspack/core':
-        specifier: 1.0.0-alpha.0
-        version: 1.0.0-alpha.0(@swc/helpers@0.5.11)
+        specifier: 1.0.0-beta.5
+        version: 1.0.0-beta.5(@swc/helpers@0.5.11)
       terser-webpack-plugin:
         specifier: 5.3.10
         version: 5.3.10(webpack@5.93.0)
@@ -2660,7 +2662,7 @@ importers:
         version: 7.23.3(@babel/core@7.24.9)
       '@rspack/cli':
         specifier: ^1.0.0-beta.1
-        version: 1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+        version: 1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(webpack-cli@4.10.0))
       '@rspack/core':
         specifier: ^1.0.0-beta.1
         version: 1.0.0-beta.1(@swc/helpers@0.5.11)
@@ -2672,19 +2674,19 @@ importers:
         version: 1.6.1(@vanilla-extract/css@1.14.0)
       '@vanilla-extract/webpack-plugin':
         specifier: ^2.3.0
-        version: 2.3.6(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(less@4.1.3)(lightningcss@1.25.1)(sass@1.69.7)(stylus@0.59.0)(terser@5.29.2)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+        version: 2.3.6(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(less@4.1.3)(lightningcss@1.25.1)(sass@1.69.7)(stylus@0.59.0)(terser@5.29.2)(webpack@5.93.0(webpack-cli@4.10.0))
       babel-loader:
         specifier: ^9.1.2
-        version: 9.1.3(@babel/core@7.24.9)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+        version: 9.1.3(@babel/core@7.24.9)(webpack@5.93.0(webpack-cli@4.10.0))
       css-loader:
         specifier: ^5.2.4
-        version: 5.2.7(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+        version: 5.2.7(webpack@5.93.0(webpack-cli@4.10.0))
       html-webpack-plugin:
         specifier: ^5.5.1
-        version: 5.6.0(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+        version: 5.6.0(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(webpack@5.93.0(webpack-cli@4.10.0))
       mini-css-extract-plugin:
         specifier: ^2.6.1
-        version: 2.8.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+        version: 2.8.0(webpack@5.93.0(webpack-cli@4.10.0))
       polished:
         specifier: ^4.1.2
         version: 4.3.1
@@ -2696,10 +2698,10 @@ importers:
         version: 17.0.2(react@17.0.2)
       tailwindcss:
         specifier: 3.3.1
-        version: 3.3.1(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+        version: 3.3.1(postcss@8.4.21)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       webpack:
         specifier: ^5.93.0
-        version: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
+        version: 5.93.0(webpack-cli@4.10.0)
       webpack-cli:
         specifier: 4.10.0
         version: 4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0)
@@ -19628,10 +19630,10 @@ snapshots:
       lodash: 4.17.21
       react: 18.2.0
 
-  '@loadable/webpack-plugin@5.15.2(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))':
+  '@loadable/webpack-plugin@5.15.2(webpack@5.93.0(esbuild@0.17.19))':
     dependencies:
       make-dir: 3.1.0
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -19761,7 +19763,7 @@ snapshots:
       '@swc/helpers': 0.5.1
       redux: 4.2.1
 
-  '@modern-js/app-tools@2.48.3(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3)))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/app-tools@2.48.3(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/parser': 7.23.9
       '@babel/traverse': 7.23.9(supports-color@5.5.0)
@@ -19773,14 +19775,14 @@ snapshots:
       '@modern-js/plugin-i18n': 2.48.3
       '@modern-js/plugin-lint': 2.48.3(eslint@8.57.0)
       '@modern-js/prod-server': 2.48.3(@types/express@4.17.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@modern-js/server': 2.48.3(@babel/traverse@7.23.9)(@types/express@4.17.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)
+      '@modern-js/server': 2.48.3(@babel/traverse@7.23.9)(@types/express@4.17.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)
       '@modern-js/server-core': 2.48.3
       '@modern-js/server-utils': 2.48.3(@babel/traverse@7.23.9)
       '@modern-js/types': 2.48.3
-      '@modern-js/uni-builder': 2.48.3(@babel/traverse@7.23.9)(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3)))(esbuild@0.17.19)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack-hot-middleware@2.26.1)
+      '@modern-js/uni-builder': 2.48.3(@babel/traverse@7.23.9)(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5)(esbuild@0.17.19)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0))(webpack-hot-middleware@2.26.1)
       '@modern-js/utils': 2.48.3
       '@rsbuild/core': 0.5.1
-      '@rsbuild/plugin-esbuild': 0.5.1(@rsbuild/core@0.5.1)(@swc/core@1.4.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)
+      '@rsbuild/plugin-esbuild': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/plugin-node-polyfill': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
       '@swc/helpers': 0.5.3
@@ -19914,14 +19916,14 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@modern-js/runtime@2.48.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))':
+  '@modern-js/runtime@2.48.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(webpack@5.93.0(esbuild@0.17.19))':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/types': 7.23.9
       '@loadable/babel-plugin': 5.15.3(@babel/core@7.23.9)
       '@loadable/component': 5.15.3(react@18.2.0)
       '@loadable/server': 5.15.3(@loadable/component@5.15.3(react@18.2.0))(react@18.2.0)
-      '@loadable/webpack-plugin': 5.15.2(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      '@loadable/webpack-plugin': 5.15.2(webpack@5.93.0(esbuild@0.17.19))
       '@modern-js-reduck/plugin-auto-actions': 1.1.11(@modern-js-reduck/store@1.1.11)
       '@modern-js-reduck/plugin-devtools': 1.1.11(@modern-js-reduck/store@1.1.11)
       '@modern-js-reduck/plugin-effects': 1.1.11(@modern-js-reduck/store@1.1.11)
@@ -19976,7 +19978,7 @@ snapshots:
       - '@babel/traverse'
       - supports-color
 
-  '@modern-js/server@2.48.3(@babel/traverse@7.23.9)(@types/express@4.17.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)':
+  '@modern-js/server@2.48.3(@babel/traverse@7.23.9)(@types/express@4.17.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/register': 7.23.7(@babel/core@7.24.9)
@@ -19993,7 +19995,7 @@ snapshots:
       path-to-regexp: 6.2.2
       ws: 8.16.0
     optionalDependencies:
-      ts-node: 10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5)
+      ts-node: 10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -20009,20 +20011,20 @@ snapshots:
 
   '@modern-js/types@2.48.3': {}
 
-  '@modern-js/uni-builder@2.48.3(@babel/traverse@7.23.9)(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3)))(esbuild@0.17.19)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack-hot-middleware@2.26.1)':
+  '@modern-js/uni-builder@2.48.3(@babel/traverse@7.23.9)(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@types/express@4.17.21)(@types/webpack@5.28.5)(esbuild@0.17.19)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)(type-fest@2.19.0)(typescript@5.4.5)(webpack-dev-server@4.13.1(webpack@5.93.0))(webpack-hot-middleware@2.26.1)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/preset-react': 7.23.3(@babel/core@7.24.9)
       '@babel/types': 7.24.5
-      '@modern-js/server': 2.48.3(@babel/traverse@7.23.9)(@types/express@4.17.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)
+      '@modern-js/server': 2.48.3(@babel/traverse@7.23.9)(@types/express@4.17.21)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(tsconfig-paths@4.2.0)
       '@modern-js/utils': 2.48.3
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3)))(react-refresh@0.14.0)(type-fest@2.19.0)(webpack-dev-server@4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@2.19.0)(webpack-dev-server@4.13.1(webpack@5.93.0))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(esbuild@0.17.19))
       '@rsbuild/babel-preset': 0.5.1
       '@rsbuild/core': 0.5.1
       '@rsbuild/plugin-assets-retry': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/plugin-babel': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/plugin-check-syntax': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
-      '@rsbuild/plugin-css-minimizer': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)(esbuild@0.17.19)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      '@rsbuild/plugin-css-minimizer': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)(esbuild@0.17.19)(webpack@5.93.0(esbuild@0.17.19))
       '@rsbuild/plugin-pug': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/plugin-react': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/plugin-rem': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
@@ -20030,18 +20032,18 @@ snapshots:
       '@rsbuild/plugin-styled-components': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/plugin-svgr': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)(typescript@5.4.5)
       '@rsbuild/plugin-toml': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
-      '@rsbuild/plugin-type-check': 0.5.1(@rsbuild/core@0.5.1)(@swc/core@1.4.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)(esbuild@0.17.19)(typescript@5.4.5)
+      '@rsbuild/plugin-type-check': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)(esbuild@0.17.19)(typescript@5.4.5)
       '@rsbuild/plugin-yaml': 0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)
       '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
-      '@rsbuild/webpack': 0.5.1(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)(esbuild@0.17.19)
+      '@rsbuild/webpack': 0.5.1(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)(esbuild@0.17.19)
       '@swc/helpers': 0.5.3
-      babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      babel-loader: 9.1.3(@babel/core@7.24.9)(webpack@5.93.0(esbuild@0.17.19))
       babel-plugin-import: 1.13.5
       babel-plugin-styled-components: 1.13.3(styled-components@6.1.11(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       babel-plugin-transform-react-remove-prop-types: 0.4.24
       cssnano: 6.0.1(postcss@8.4.38)
       glob: 9.3.5
-      html-webpack-plugin: 5.5.3(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      html-webpack-plugin: 5.5.3(webpack@5.93.0)
       lodash: 4.17.21
       postcss: 8.4.38
       postcss-custom-properties: 13.1.5(postcss@8.4.38)
@@ -20052,12 +20054,12 @@ snapshots:
       postcss-nesting: 12.0.1(postcss@8.4.38)
       postcss-page-break: 3.0.4(postcss@8.4.38)
       react-refresh: 0.14.0
-      rspack-manifest-plugin: 5.0.0-alpha0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
-      ts-loader: 9.4.4(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      webpack-manifest-plugin: 5.0.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.3(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      rspack-manifest-plugin: 5.0.0-alpha0(webpack@5.93.0(esbuild@0.17.19))
+      terser-webpack-plugin: 5.3.10(esbuild@0.17.19)(webpack@5.93.0(esbuild@0.17.19))
+      ts-loader: 9.4.4(typescript@5.4.5)(webpack@5.93.0(esbuild@0.17.19))
+      webpack: 5.93.0(esbuild@0.17.19)
+      webpack-manifest-plugin: 5.0.0(webpack@5.93.0(esbuild@0.17.19))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.3(webpack@5.93.0))(webpack@5.93.0(esbuild@0.17.19))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -20092,14 +20094,14 @@ snapshots:
   '@modern-js/utils@2.48.3':
     dependencies:
       '@swc/helpers': 0.5.3
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       lodash: 4.17.21
       rslog: 1.2.1
 
   '@modern-js/utils@2.56.2':
     dependencies:
       '@swc/helpers': 0.5.3
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       lodash: 4.17.21
       rslog: 1.2.1
 
@@ -20449,7 +20451,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.10(@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3)))(react-refresh@0.14.0)(type-fest@2.19.0)(webpack-dev-server@4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.10(@types/webpack@5.28.5)(react-refresh@0.14.0)(type-fest@2.19.0)(webpack-dev-server@4.13.1(webpack@5.93.0))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(esbuild@0.17.19))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -20461,11 +20463,11 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
     optionalDependencies:
-      '@types/webpack': 5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      '@types/webpack': 5.28.5
       type-fest: 2.19.0
-      webpack-dev-server: 4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      webpack-dev-server: 4.13.1(webpack@5.93.0)
       webpack-hot-middleware: 2.26.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.11(@types/webpack@5.28.5(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0)))(react-refresh@0.14.0)(type-fest@4.18.2)(webpack-dev-server@4.13.1(webpack-cli@4.10.0)(webpack@5.93.0))(webpack-hot-middleware@2.26.1)(webpack@5.93.0(webpack-cli@4.10.0))':
@@ -20749,7 +20751,7 @@ snapshots:
       '@rspack/core': 1.0.0-alpha.3(@swc/helpers@0.5.11)
       '@rspack/lite-tapable': 1.0.0-alpha.3
       '@swc/helpers': 0.5.11
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       core-js: 3.37.1
       postcss: 8.4.39
     optionalDependencies:
@@ -20817,11 +20819,11 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@rsbuild/plugin-css-minimizer@0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)(esbuild@0.17.19)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))':
+  '@rsbuild/plugin-css-minimizer@0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)(esbuild@0.17.19)(webpack@5.93.0(esbuild@0.17.19))':
     dependencies:
       '@rsbuild/core': 0.5.1
       '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
-      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.17.19)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.17.19)(webpack@5.93.0(esbuild@0.17.19))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -20832,12 +20834,12 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-esbuild@0.5.1(@rsbuild/core@0.5.1)(@swc/core@1.4.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)':
+  '@rsbuild/plugin-esbuild@0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)':
     dependencies:
       '@rsbuild/core': 0.5.1
       '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
       esbuild: 0.17.19
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)
+      webpack: 5.93.0(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/helpers'
@@ -21016,11 +21018,11 @@ snapshots:
       '@swc/plugin-styled-components': 2.0.10
       reduce-configs: 1.0.0
 
-  '@rsbuild/plugin-svelte@1.0.1-beta.9(@babel/core@7.24.9)(@rsbuild/core@1.0.1-beta.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3)':
+  '@rsbuild/plugin-svelte@1.0.1-beta.9(@babel/core@7.24.9)(@rsbuild/core@1.0.1-beta.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3)':
     dependencies:
       '@rsbuild/core': 1.0.1-beta.9
       svelte-loader: 3.2.3(svelte@4.2.11)
-      svelte-preprocess: 6.0.2(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3)
+      svelte-preprocess: 6.0.2(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3)
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -21054,12 +21056,12 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@rsbuild/plugin-type-check@0.5.1(@rsbuild/core@0.5.1)(@swc/core@1.4.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)(esbuild@0.17.19)(typescript@5.4.5)':
+  '@rsbuild/plugin-type-check@0.5.1(@rsbuild/core@0.5.1)(@swc/helpers@0.5.3)(esbuild@0.17.19)(typescript@5.4.5)':
     dependencies:
       '@rsbuild/core': 0.5.1
       '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
-      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)
+      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.4.5)(webpack@5.93.0(esbuild@0.17.19))
+      webpack: 5.93.0(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/helpers'
@@ -21072,10 +21074,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.0.1-beta.9
 
-  '@rsbuild/plugin-vue2@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0))':
+  '@rsbuild/plugin-vue2@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5)(webpack@5.93.0))':
     dependencies:
       '@rsbuild/core': 1.0.1-beta.9
-      vue-loader: 15.11.1(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0))(webpack@5.93.0)
+      vue-loader: 15.11.1(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5)(webpack@5.93.0))(webpack@5.93.0)
       webpack: 5.93.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -21177,7 +21179,7 @@ snapshots:
   '@rsbuild/shared@0.5.1(@swc/helpers@0.5.3)':
     dependencies:
       '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       postcss: 8.4.38
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -21185,7 +21187,7 @@ snapshots:
   '@rsbuild/shared@0.5.2(@swc/helpers@0.5.3)':
     dependencies:
       '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       postcss: 8.4.39
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -21193,7 +21195,7 @@ snapshots:
   '@rsbuild/shared@1.0.0-alpha.0(@swc/helpers@0.5.11)':
     dependencies:
       '@rspack/core': 1.0.0-alpha.0(@swc/helpers@0.5.11)
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@1.0.0-alpha.0(@swc/helpers@0.5.11))
       postcss: 8.4.39
     optionalDependencies:
@@ -21201,17 +21203,17 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@rsbuild/webpack@0.5.1(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)(esbuild@0.17.19)':
+  '@rsbuild/webpack@0.5.1(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)(esbuild@0.17.19)':
     dependencies:
       '@rsbuild/core': 0.5.1
       '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
       fast-glob: 3.3.2
       globby: 11.1.0
       html-webpack-plugin: html-rspack-plugin@5.6.2(@rspack/core@0.5.8(@swc/helpers@0.5.3))
-      mini-css-extract-plugin: 2.8.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      mini-css-extract-plugin: 2.8.1(webpack@5.93.0(esbuild@0.17.19))
       postcss: 8.4.39
       tsconfig-paths-webpack-plugin: 4.1.0
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)
+      webpack: 5.93.0(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -21220,12 +21222,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsdoctor/cli@0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))':
+  '@rsdoctor/cli@0.3.10(@rspack/core@0.7.5)':
     dependencies:
       '@rsdoctor/client': 0.3.10
-      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
+      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5)
       axios: 1.7.2
       chalk: 4.1.2
       ora: 5.4.1
@@ -21272,40 +21274,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@rsdoctor/core@0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))':
+  '@rsdoctor/core@0.3.10(@rspack/core@0.7.5)':
     dependencies:
-      '@rsdoctor/graph': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      axios: 1.7.2
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.4
-      fs-extra: 11.2.0
-      loader-utils: 2.0.4
-      lodash: 4.17.21
-      path-browserify: 1.0.1
-      semver: 7.6.3
-      source-map: 0.7.4
-      webpack-bundle-analyzer: 4.10.2
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - bufferutil
-      - debug
-      - esbuild
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
-  '@rsdoctor/core@0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))':
-    dependencies:
-      '@rsdoctor/graph': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
+      '@rsdoctor/graph': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5)
       axios: 1.7.2
       enhanced-resolve: 5.12.0
       filesize: 10.1.4
@@ -21373,27 +21347,10 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@rsdoctor/graph@0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))':
+  '@rsdoctor/graph@0.3.10(@rspack/core@0.7.5)':
     dependencies:
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      lodash: 4.17.21
-      socket.io: 4.7.2
-      source-map: 0.7.4
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - bufferutil
-      - esbuild
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
-  '@rsdoctor/graph@0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))':
-    dependencies:
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
+      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5)
       lodash: 4.17.21
       socket.io: 4.7.2
       source-map: 0.7.4
@@ -21431,26 +21388,6 @@ snapshots:
       '@rsdoctor/sdk': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))
       '@rsdoctor/types': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))
       '@rsdoctor/utils': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))
-      '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
-      loader-utils: 2.0.4
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - '@swc/core'
-      - bufferutil
-      - debug
-      - esbuild
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
-  '@rsdoctor/rspack-plugin@0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))':
-    dependencies:
-      '@rsdoctor/core': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/graph': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
       '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
       loader-utils: 2.0.4
       lodash: 4.17.21
@@ -21509,37 +21446,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@rsdoctor/sdk@0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))':
+  '@rsdoctor/sdk@0.3.10(@rspack/core@0.7.5)':
     dependencies:
       '@rsdoctor/client': 0.3.10
-      '@rsdoctor/graph': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      body-parser: 1.20.2
-      cors: 2.8.5
-      dayjs: 1.11.12
-      lodash: 4.17.21
-      open: 8.4.2
-      serve-static: 1.15.0
-      socket.io: 4.7.2
-      source-map: 0.7.4
-      tapable: 2.2.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - bufferutil
-      - esbuild
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-
-  '@rsdoctor/sdk@0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))':
-    dependencies:
-      '@rsdoctor/client': 0.3.10
-      '@rsdoctor/graph': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
+      '@rsdoctor/graph': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5)
       body-parser: 1.20.2
       cors: 2.8.5
       dayjs: 1.11.12
@@ -21599,30 +21511,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsdoctor/types@0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))':
+  '@rsdoctor/types@0.3.10(@rspack/core@0.7.5)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.2.7
-      '@types/webpack': 5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      '@types/webpack': 5.28.5
       source-map: 0.7.4
     optionalDependencies:
-      '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@rsdoctor/types@0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
-      '@types/webpack': 5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      source-map: 0.7.4
-    optionalDependencies:
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.11)
+      '@rspack/core': 0.7.5
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -21672,38 +21569,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsdoctor/utils@0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))':
+  '@rsdoctor/utils@0.3.10(@rspack/core@0.7.5)':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.5.8(@swc/helpers@0.5.3))(@swc/core@1.4.8(@swc/helpers@0.5.3))
-      '@types/estree': 1.0.5
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
-      acorn-walk: 8.3.3
-      chalk: 4.1.2
-      connect: 3.7.0
-      deep-eql: 4.1.4
-      envinfo: 7.13.0
-      filesize: 10.1.4
-      fs-extra: 11.2.0
-      get-port: 5.1.1
-      json-stream-stringify: 3.0.1
-      lines-and-columns: 2.0.4
-      lodash: 4.17.21
-      rslog: 1.2.2
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - esbuild
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@rsdoctor/utils@0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))':
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
+      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5)
       '@types/estree': 1.0.5
       acorn: 8.11.3
       acorn-import-assertions: 1.9.0(acorn@8.11.3)
@@ -21756,16 +21625,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@rsdoctor/webpack-plugin@0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11)))':
+  '@rsdoctor/webpack-plugin@0.3.10(@rspack/core@0.7.5)(webpack@5.93.0)':
     dependencies:
-      '@rsdoctor/core': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/graph': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
-      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5(@swc/helpers@0.5.11))(@swc/core@1.4.8(@swc/helpers@0.5.11))
+      '@rsdoctor/core': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/graph': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/sdk': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/types': 0.3.10(@rspack/core@0.7.5)
+      '@rsdoctor/utils': 0.3.10(@rspack/core@0.7.5)
       fs-extra: 11.2.0
       lodash: 4.17.21
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))
+      webpack: 5.93.0
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -22075,11 +21944,11 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@rspack/cli@1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))':
+  '@rspack/cli@1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(webpack-cli@4.10.0))':
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@rspack/core': 1.0.0-beta.1(@swc/helpers@0.5.11)
-      '@rspack/dev-server': 1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+      '@rspack/dev-server': 1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(webpack-cli@4.10.0))
       colorette: 2.0.19
       exit-hook: 3.2.0
       interpret: 3.1.1
@@ -22219,15 +22088,13 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.3
 
-  '@rspack/core@0.7.5(@swc/helpers@0.5.11)':
+  '@rspack/core@0.7.5':
     dependencies:
       '@module-federation/runtime-tools': 0.1.6
       '@rspack/binding': 0.7.5
       caniuse-lite: 1.0.30001646
       tapable: 2.2.1
       webpack-sources: 3.2.3
-    optionalDependencies:
-      '@swc/helpers': 0.5.11
     optional: true
 
   '@rspack/core@1.0.0-alpha.0(@swc/helpers@0.5.11)':
@@ -22244,7 +22111,7 @@ snapshots:
       '@module-federation/runtime-tools': 0.2.3
       '@rspack/binding': 1.0.0-alpha.3
       '@rspack/lite-tapable': 1.0.0-alpha.3
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
     optionalDependencies:
       '@swc/helpers': 0.5.11
 
@@ -22335,7 +22202,7 @@ snapshots:
       - webpack
       - webpack-cli
 
-  '@rspack/dev-server@1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))':
+  '@rspack/dev-server@1.0.0-beta.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(@types/express@4.17.21)(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(webpack-cli@4.10.0))':
     dependencies:
       '@rspack/core': 1.0.0-beta.1(@swc/helpers@0.5.11)
       chokidar: 3.6.0
@@ -22343,8 +22210,8 @@ snapshots:
       express: 4.19.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
       mime-types: 2.1.35
-      webpack-dev-middleware: 7.3.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
-      webpack-dev-server: 5.0.4(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+      webpack-dev-middleware: 7.3.0(webpack@5.93.0(webpack-cli@4.10.0))
+      webpack-dev-server: 5.0.4(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(webpack-cli@4.10.0))
       ws: 8.16.0
     transitivePeerDependencies:
       - '@types/express'
@@ -22959,24 +22826,6 @@ snapshots:
       '@swc/core-win32-ia32-msvc': 1.4.8
       '@swc/core-win32-x64-msvc': 1.4.8
       '@swc/helpers': 0.5.11
-
-  '@swc/core@1.4.8(@swc/helpers@0.5.3)':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.5
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.4.8
-      '@swc/core-darwin-x64': 1.4.8
-      '@swc/core-linux-arm-gnueabihf': 1.4.8
-      '@swc/core-linux-arm64-gnu': 1.4.8
-      '@swc/core-linux-arm64-musl': 1.4.8
-      '@swc/core-linux-x64-gnu': 1.4.8
-      '@swc/core-linux-x64-musl': 1.4.8
-      '@swc/core-win32-arm64-msvc': 1.4.8
-      '@swc/core-win32-ia32-msvc': 1.4.8
-      '@swc/core-win32-x64-msvc': 1.4.8
-      '@swc/helpers': 0.5.3
-    optional: true
 
   '@swc/counter@0.1.3': {}
 
@@ -24264,28 +24113,6 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.11))':
-    dependencies:
-      '@types/node': 20.12.12
-      tapable: 2.2.1
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@types/webpack@5.28.5(@swc/core@1.4.8(@swc/helpers@0.5.3))':
-    dependencies:
-      '@types/node': 20.12.12
-      tapable: 2.2.1
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
   '@types/webpack@5.28.5(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))':
     dependencies:
       '@types/node': 20.12.12
@@ -24372,7 +24199,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.0
+      semver: 7.6.3
       ts-api-utils: 1.2.1(typescript@5.3.3)
     optionalDependencies:
       typescript: 5.3.3
@@ -24388,7 +24215,7 @@ snapshots:
       '@typescript-eslint/types': 7.1.0
       '@typescript-eslint/typescript-estree': 7.1.0(typescript@5.3.3)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24495,13 +24322,13 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.14.0
 
-  '@vanilla-extract/webpack-plugin@2.3.6(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(less@4.1.3)(lightningcss@1.25.1)(sass@1.69.7)(stylus@0.59.0)(terser@5.29.2)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))':
+  '@vanilla-extract/webpack-plugin@2.3.6(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(less@4.1.3)(lightningcss@1.25.1)(sass@1.69.7)(stylus@0.59.0)(terser@5.29.2)(webpack@5.93.0(webpack-cli@4.10.0))':
     dependencies:
       '@vanilla-extract/integration': 7.1.1(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(less@4.1.3)(lightningcss@1.25.1)(sass@1.69.7)(stylus@0.59.0)(terser@5.29.2)
       chalk: 4.1.2
       debug: 4.3.4(supports-color@5.5.0)
       loader-utils: 2.0.4
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
+      webpack: 5.93.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25431,19 +25258,19 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.93.0
 
-  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)):
+  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       '@babel/core': 7.24.9
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
+      webpack: 5.93.0(esbuild@0.17.19)
 
-  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.93.0(webpack-cli@4.10.0)):
     dependencies:
       '@babel/core': 7.24.9
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(webpack-cli@4.10.0)
 
   babel-loader@9.1.3(@babel/core@7.24.9)(webpack@5.93.0):
     dependencies:
@@ -25865,7 +25692,7 @@ snapshots:
 
   browserslist@4.23.0:
     dependencies:
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       electron-to-chromium: 1.4.676
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
@@ -25998,7 +25825,7 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.23.2
-      caniuse-lite: 1.0.30001643
+      caniuse-lite: 1.0.30001646
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
@@ -26537,7 +26364,7 @@ snapshots:
     dependencies:
       postcss: 8.4.39
 
-  css-loader@5.2.7(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)):
+  css-loader@5.2.7(webpack@5.93.0(webpack-cli@4.10.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.21)
       loader-utils: 2.0.4
@@ -26549,7 +26376,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.6.0
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
+      webpack: 5.93.0(webpack-cli@4.10.0)
 
   css-loader@6.10.0(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.1))(webpack@5.93.0(@swc/core@1.4.2(@swc/helpers@0.5.1))):
     dependencies:
@@ -26591,7 +26418,7 @@ snapshots:
       semver: 7.6.0
       webpack: 5.93.0
 
-  css-loader@7.1.1(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0):
+  css-loader@7.1.1(@rspack/core@0.7.5)(webpack@5.93.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -26602,7 +26429,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.0
     optionalDependencies:
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.11)
+      '@rspack/core': 0.7.5
       webpack: 5.93.0
 
   css-loader@7.1.1(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.1))(webpack@5.93.0):
@@ -26635,7 +26462,7 @@ snapshots:
 
   css-mediaquery@0.1.2: {}
 
-  css-minimizer-webpack-plugin@5.0.1(esbuild@0.17.19)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  css-minimizer-webpack-plugin@5.0.1(esbuild@0.17.19)(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       cssnano: 6.0.1(postcss@8.4.39)
@@ -26643,7 +26470,7 @@ snapshots:
       postcss: 8.4.39
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
     optionalDependencies:
       esbuild: 0.17.19
 
@@ -28105,7 +27932,7 @@ snapshots:
       typescript: 5.4.5
       webpack: 5.93.0
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.4.5)(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       '@babel/code-frame': 7.24.7
       chalk: 4.1.2
@@ -28120,7 +27947,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.4.5
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)
+      webpack: 5.93.0(esbuild@0.17.19)
 
   form-data@4.0.0:
     dependencies:
@@ -28698,16 +28525,16 @@ snapshots:
 
   html-void-elements@2.0.1: {}
 
-  html-webpack-plugin@5.5.3(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  html-webpack-plugin@5.5.3(webpack@5.93.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
 
-  html-webpack-plugin@5.6.0(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.6.0(@rspack/core@0.7.5)(webpack@5.93.0(webpack-cli@4.10.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -28715,7 +28542,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      '@rspack/core': 0.7.5(@swc/helpers@0.5.11)
+      '@rspack/core': 0.7.5
       webpack: 5.93.0(webpack-cli@4.10.0)
 
   html-webpack-plugin@5.6.0(@rspack/core@1.0.0-alpha.0(@swc/helpers@0.5.11))(webpack@5.93.0):
@@ -28729,7 +28556,7 @@ snapshots:
       '@rspack/core': 1.0.0-alpha.0(@swc/helpers@0.5.11)
       webpack: 5.93.0
 
-  html-webpack-plugin@5.6.0(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.6.0(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(webpack@5.93.0(webpack-cli@4.10.0)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -28738,7 +28565,7 @@ snapshots:
       tapable: 2.2.1
     optionalDependencies:
       '@rspack/core': 1.0.0-beta.1(@swc/helpers@0.5.11)
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
+      webpack: 5.93.0(webpack-cli@4.10.0)
 
   html-webpack-plugin@5.6.0(@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11))(webpack@5.93.0):
     dependencies:
@@ -30984,17 +30811,17 @@ snapshots:
       tapable: 2.2.1
       webpack: 5.93.0(@swc/core@1.4.2(@swc/helpers@0.5.1))
 
-  mini-css-extract-plugin@2.8.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)):
+  mini-css-extract-plugin@2.8.0(webpack@5.93.0(webpack-cli@4.10.0)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
+      webpack: 5.93.0(webpack-cli@4.10.0)
 
-  mini-css-extract-plugin@2.8.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  mini-css-extract-plugin@2.8.1(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)
+      webpack: 5.93.0(esbuild@0.17.19)
 
   minimalistic-assert@1.0.1: {}
 
@@ -31775,7 +31602,7 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.38
 
-  postcss-load-config@3.1.4(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)):
+  postcss-load-config@3.1.4(postcss@8.4.21)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
@@ -31783,7 +31610,7 @@ snapshots:
       postcss: 8.4.21
       ts-node: 10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)
 
-  postcss-load-config@4.0.1(postcss@8.4.35)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.2)):
+  postcss-load-config@4.0.1(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.4
@@ -31791,15 +31618,15 @@ snapshots:
       postcss: 8.4.35
       ts-node: 10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.2)
 
-  postcss-load-config@4.0.1(postcss@8.4.35)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.6)(typescript@5.4.2)):
+  postcss-load-config@4.0.1(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.12.6)(typescript@5.4.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.4
     optionalDependencies:
       postcss: 8.4.35
-      ts-node: 10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.6)(typescript@5.4.2)
+      ts-node: 10.9.2(@types/node@20.12.6)(typescript@5.4.2)
 
-  postcss-load-config@4.0.1(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)):
+  postcss-load-config@4.0.1(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.4
@@ -31807,16 +31634,7 @@ snapshots:
       postcss: 8.4.38
       ts-node: 10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)
 
-  postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3)):
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 2.3.4
-    optionalDependencies:
-      postcss: 8.4.39
-      ts-node: 10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3)
-    optional: true
-
-  postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)):
+  postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 2.3.4
@@ -33115,10 +32933,10 @@ snapshots:
 
   rslog@1.2.2: {}
 
-  rspack-manifest-plugin@5.0.0-alpha0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  rspack-manifest-plugin@5.0.0-alpha0(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       tapable: 2.2.1
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
       webpack-sources: 2.3.1
 
   rspack-manifest-plugin@5.0.0-alpha0(webpack@5.93.0):
@@ -34107,7 +33925,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.6.4(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2):
+  svelte-check@3.6.4(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.22
       chokidar: 3.6.0
@@ -34116,7 +33934,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.59.2
-      svelte-preprocess: 5.1.3(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)(typescript@5.4.5)
+      svelte-preprocess: 5.1.3(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -34153,7 +33971,7 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@4.2.11)
 
-  svelte-preprocess@5.1.3(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)(typescript@5.4.5):
+  svelte-preprocess@5.1.3(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(svelte@3.59.2)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -34165,19 +33983,19 @@ snapshots:
       '@babel/core': 7.24.9
       less: 4.1.3
       postcss: 8.4.39
-      postcss-load-config: 4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+      postcss-load-config: 4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       pug: 3.0.2
       sass: 1.69.7
       typescript: 5.4.5
 
-  svelte-preprocess@6.0.2(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3):
+  svelte-preprocess@6.0.2(@babel/core@7.24.9)(less@4.1.3)(postcss-load-config@4.0.1(postcss@8.4.39))(postcss@8.4.39)(pug@3.0.2)(sass@1.69.7)(stylus@0.59.0)(svelte@4.2.11)(typescript@5.3.3):
     dependencies:
       svelte: 4.2.11
     optionalDependencies:
       '@babel/core': 7.24.9
       less: 4.1.3
       postcss: 8.4.39
-      postcss-load-config: 4.0.1(postcss@8.4.39)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3))
+      postcss-load-config: 4.0.1(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       pug: 3.0.2
       sass: 1.69.7
       stylus: 0.59.0
@@ -34255,11 +34073,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.24.4
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))):
     dependencies:
-      tailwindcss: 3.4.3(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
 
-  tailwindcss@3.3.1(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)):
+  tailwindcss@3.3.1(postcss@8.4.21)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)):
     dependencies:
       arg: 5.0.2
       chokidar: 3.6.0
@@ -34278,7 +34096,7 @@ snapshots:
       postcss: 8.4.21
       postcss-import: 14.1.0(postcss@8.4.21)
       postcss-js: 4.0.1(postcss@8.4.21)
-      postcss-load-config: 3.1.4(postcss@8.4.21)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+      postcss-load-config: 3.1.4(postcss@8.4.21)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       postcss-nested: 6.0.0(postcss@8.4.21)
       postcss-selector-parser: 6.0.15
       postcss-value-parser: 4.2.0
@@ -34288,7 +34106,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.1(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.2)):
+  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -34307,7 +34125,7 @@ snapshots:
       postcss: 8.4.35
       postcss-import: 15.1.0(postcss@8.4.35)
       postcss-js: 4.0.1(postcss@8.4.35)
-      postcss-load-config: 4.0.1(postcss@8.4.35)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.2))
+      postcss-load-config: 4.0.1(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.2))
       postcss-nested: 6.0.1(postcss@8.4.35)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
@@ -34315,7 +34133,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.1(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.6)(typescript@5.4.2)):
+  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.12.6)(typescript@5.4.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -34334,7 +34152,7 @@ snapshots:
       postcss: 8.4.35
       postcss-import: 15.1.0(postcss@8.4.35)
       postcss-js: 4.0.1(postcss@8.4.35)
-      postcss-load-config: 4.0.1(postcss@8.4.35)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.6)(typescript@5.4.2))
+      postcss-load-config: 4.0.1(postcss@8.4.35)(ts-node@10.9.2(@types/node@20.12.6)(typescript@5.4.2))
       postcss-nested: 6.0.1(postcss@8.4.35)
       postcss-selector-parser: 6.0.15
       resolve: 1.22.8
@@ -34342,7 +34160,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.3(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5)):
+  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -34361,7 +34179,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.1(postcss@8.4.38)(ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.5))
+      postcss-load-config: 4.0.1(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.0.16
       resolve: 1.22.8
@@ -34434,17 +34252,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.2(@swc/helpers@0.5.1)
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.29.2
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
-    optionalDependencies:
-      '@swc/core': 1.4.8(@swc/helpers@0.5.11)
-
   terser-webpack-plugin@5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -34456,28 +34263,16 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.8(@swc/helpers@0.5.11)
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  terser-webpack-plugin@5.3.10(esbuild@0.17.19)(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.29.2
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)
+      webpack: 5.93.0(esbuild@0.17.19)
     optionalDependencies:
-      '@swc/core': 1.4.8(@swc/helpers@0.5.3)
       esbuild: 0.17.19
-
-  terser-webpack-plugin@5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.3))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.29.2
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
-    optionalDependencies:
-      '@swc/core': 1.4.8(@swc/helpers@0.5.3)
 
   terser-webpack-plugin@5.3.10(esbuild@0.19.3)(webpack@5.93.0(esbuild@0.19.3)):
     dependencies:
@@ -34659,14 +34454,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.4.2(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  ts-loader@9.4.2(typescript@5.4.5)(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.15.0
       micromatch: 4.0.5
       semver: 7.6.0
       typescript: 5.4.5
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
 
   ts-loader@9.4.2(typescript@5.4.5)(webpack@5.93.0):
     dependencies:
@@ -34677,35 +34472,14 @@ snapshots:
       typescript: 5.4.5
       webpack: 5.93.0
 
-  ts-loader@9.4.4(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  ts-loader@9.4.4(typescript@5.4.5)(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.17.0
       micromatch: 4.0.5
       semver: 7.6.3
       typescript: 5.4.5
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
-
-  ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.3.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.12.12
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.3.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.4.8(@swc/helpers@0.5.11)
-    optional: true
+      webpack: 5.93.0(esbuild@0.17.19)
 
   ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.12)(typescript@5.4.2):
     dependencies:
@@ -34747,7 +34521,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.8(@swc/helpers@0.5.11)
 
-  ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.11))(@types/node@20.12.6)(typescript@5.4.2):
+  ts-node@10.9.2(@types/node@20.12.6)(typescript@5.4.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -34764,29 +34538,6 @@ snapshots:
       typescript: 5.4.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.4.8(@swc/helpers@0.5.11)
-    optional: true
-
-  ts-node@10.9.2(@swc/core@1.4.8(@swc/helpers@0.5.3))(@types/node@20.12.12)(typescript@5.4.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.12.12
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.4.8(@swc/helpers@0.5.3)
     optional: true
 
   tsconfig-paths-webpack-plugin@4.1.0:
@@ -35211,7 +34962,7 @@ snapshots:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.6.0
+      semver: 7.6.3
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
 
@@ -35464,10 +35215,10 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0))(webpack@5.93.0):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.19)(css-loader@7.1.1(@rspack/core@0.7.5)(webpack@5.93.0))(webpack@5.93.0):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.9)(handlebars@4.7.8)(lodash@4.17.21)(pug@3.0.2)
-      css-loader: 7.1.1(@rspack/core@0.7.5(@swc/helpers@0.5.11))(webpack@5.93.0)
+      css-loader: 7.1.1(@rspack/core@0.7.5)(webpack@5.93.0)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
@@ -35827,16 +35578,6 @@ snapshots:
       webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@5.3.3(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
-    optional: true
-
   webpack-dev-middleware@5.3.3(webpack@5.93.0(webpack-cli@4.10.0)):
     dependencies:
       colorette: 2.0.20
@@ -35853,7 +35594,7 @@ snapshots:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.93.0
+      webpack: 5.93.0(esbuild@0.17.19)
 
   webpack-dev-middleware@6.1.2(webpack@5.93.0):
     dependencies:
@@ -35876,17 +35617,6 @@ snapshots:
     optionalDependencies:
       webpack: 5.93.0(@swc/core@1.4.2(@swc/helpers@0.5.1))
 
-  webpack-dev-middleware@7.3.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 4.11.0
-      mime-types: 2.1.35
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-    optionalDependencies:
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
-
   webpack-dev-middleware@7.3.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))):
     dependencies:
       colorette: 2.0.20
@@ -35908,6 +35638,17 @@ snapshots:
       schema-utils: 4.2.0
     optionalDependencies:
       webpack: 5.93.0(esbuild@0.19.3)
+
+  webpack-dev-middleware@7.3.0(webpack@5.93.0(webpack-cli@4.10.0)):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 4.11.0
+      mime-types: 2.1.35
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      schema-utils: 4.2.0
+    optionalDependencies:
+      webpack: 5.93.0(webpack-cli@4.10.0)
 
   webpack-dev-middleware@7.3.0(webpack@5.93.0(webpack-cli@5.1.4)):
     dependencies:
@@ -35972,47 +35713,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@4.13.1(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.21
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.5
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.10
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.2.1
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.19.2
-      graceful-fs: 4.2.11
-      html-entities: 2.4.0
-      http-proxy-middleware: 2.0.6(@types/express@4.17.21)
-      ipaddr.js: 2.1.0
-      launch-editor: 2.6.1
-      open: 8.4.2
-      p-retry: 4.6.2
-      rimraf: 3.0.2
-      schema-utils: 4.2.0
-      selfsigned: 2.4.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
-      ws: 8.16.0
-    optionalDependencies:
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   webpack-dev-server@4.13.1(webpack@5.93.0):
     dependencies:
       '@types/bonjour': 3.5.13
@@ -36046,14 +35746,14 @@ snapshots:
       webpack-dev-middleware: 5.3.3(webpack@5.93.0)
       ws: 8.16.0
     optionalDependencies:
-      webpack: 5.93.0
+      webpack: 5.93.0(esbuild@0.17.19)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.0.4(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)):
+  webpack-dev-server@5.0.4(webpack-cli@4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0))(webpack@5.93.0(webpack-cli@4.10.0)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -36083,10 +35783,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.3.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
+      webpack-dev-middleware: 7.3.0(webpack@5.93.0(webpack-cli@4.10.0))
       ws: 8.16.0
     optionalDependencies:
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0)
+      webpack: 5.93.0(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0)
     transitivePeerDependencies:
       - bufferutil
@@ -36307,10 +36007,10 @@ snapshots:
       ansi-colors: 3.2.4
       uuid: 3.4.0
 
-  webpack-manifest-plugin@5.0.0(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  webpack-manifest-plugin@5.0.0(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       tapable: 2.2.1
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
       webpack-sources: 2.3.1
 
   webpack-merge@5.10.0:
@@ -36333,12 +36033,12 @@ snapshots:
 
   webpack-stats-plugin@1.1.3: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.3(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.3(webpack@5.93.0))(webpack@5.93.0(esbuild@0.17.19)):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))
+      webpack: 5.93.0(esbuild@0.17.19)
     optionalDependencies:
-      html-webpack-plugin: 5.5.3(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      html-webpack-plugin: 5.5.3(webpack@5.93.0)
 
   webpack-virtual-modules@0.6.1: {}
 
@@ -36466,7 +36166,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0):
+  webpack@5.93.0(esbuild@0.17.19):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -36489,71 +36189,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.11))(webpack-cli@4.10.0))
-      watchpack: 2.4.1
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-dev-server@4.13.1)(webpack@5.93.0)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3)):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.5
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.11.3
-      acorn-import-attributes: 1.9.5(acorn@8.11.3)
-      browserslist: 4.23.2
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.17.0
-      es-module-lexer: 1.4.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.3))(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
-      watchpack: 2.4.1
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.5
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.11.3
-      acorn-import-attributes: 1.9.5(acorn@8.11.3)
-      browserslist: 4.23.2
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.17.0
-      es-module-lexer: 1.4.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19)(webpack@5.93.0(@swc/core@1.4.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+      terser-webpack-plugin: 5.3.10(esbuild@0.17.19)(webpack@5.93.0(esbuild@0.17.19))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/rspack/terser-webpack-plugin/package.json
+++ b/rspack/terser-webpack-plugin/package.json
@@ -5,8 +5,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "1.0.0-alpha.0",
-    "@rspack/core": "1.0.0-alpha.0",
+    "@rspack/cli": "1.0.0-beta.5",
+    "@rspack/core": "1.0.0-beta.5",
     "terser-webpack-plugin": "5.3.10"
   }
 }

--- a/rspack/terser-webpack-plugin/rspack.config.js
+++ b/rspack/terser-webpack-plugin/rspack.config.js
@@ -5,6 +5,6 @@ const rspack = require('@rspack/core');
 module.exports = defineConfig({
   plugins: [new StatsWriterPlugin()],
   optimization: {
-    minimizer: [new terserPlugin(), new rspack.SwcCssMinimizerRspackPlugin()],
+    minimizer: [new terserPlugin(), new rspack.LightningCssMinimizerRspackPlugin()],
   },
 });


### PR DESCRIPTION
fix: https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/10405299644/job/28815915849

use LightningCssMinimizerRspackPlugin instead of SwcCssMinimizer.

see detail: https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0-beta.5#:~:text=Removed%20SwcCssMinimizerRspackPlugin