### PR TITLE
fix: enable extract-license build

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1445,8 +1445,6 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0
 
-  rspack/generate-package-json-webpack-plugin@2/dist: {}
-
   rspack/html-webpack-plugin:
     devDependencies:
       '@rspack/cli':

--- a/rspack/extract-license/package.json
+++ b/rspack/extract-license/package.json
@@ -6,7 +6,7 @@
   "sideEffects": ["**/*.css", "**/*.less", "**/*.scss"],
   "main": "index.js",
   "scripts": {
-    "build": "echo success",
+    "build": "rspack build",
     "dev": "rspack serve"
   },
   "dependencies": {


### PR DESCRIPTION
don't know why the build is disabled before, but it seems it can build successfully so enable it