### PR TITLE
fix: pnpm workspace exclude dist folder

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "rsbuild/**"
   - "rspress/**"
   - "rsdoctor/**"
+  - "!**/dist"


### PR DESCRIPTION
pnpm workspace should exclude the dist folder