### PR TITLE
fix: express afterListen typo

### DIFF
--- a/rsbuild/express/server.mjs
+++ b/rsbuild/express/server.mjs
@@ -17,9 +17,9 @@ export async function startDevServer() {
   // Apply Rsbuild’s built-in middlewares
   app.use(rsbuildServer.middlewares);
 
-  const httpServer = app.listen(rsbuildServer.port, async () => {
+  const httpServer = app.listen(rsbuildServer.port, () => {
     // Notify Rsbuild that the custom server has started
-    await rsbuildServer.afterListen();
+    rsbuildServer.afterListen();
   });
 
   rsbuildServer.connectWebSocket({ server: httpServer });
@@ -32,4 +32,4 @@ export async function startDevServer() {
   };
 }
 
-startDevServer(process.cwd());
+startDevServer();

--- a/rsbuild/ssr-express/server.mjs
+++ b/rsbuild/ssr-express/server.mjs
@@ -43,9 +43,9 @@ export async function startDevServer() {
   // Apply Rsbuild’s built-in middlewares
   app.use(rsbuildServer.middlewares);
 
-  const httpServer = app.listen(rsbuildServer.port, async () => {
+  const httpServer = app.listen(rsbuildServer.port, () => {
     // Notify Rsbuild that the custom server has started
-    await rsbuildServer.afterListen();
+    rsbuildServer.afterListen();
   });
 
   rsbuildServer.connectWebSocket({ server: httpServer });
@@ -58,4 +58,4 @@ export async function startDevServer() {
   };
 }
 
-startDevServer(process.cwd());
+startDevServer();


### PR DESCRIPTION
fix: https://github.com/rspack-contrib/rspack-examples/issues/142

Typing error in express example.

https://typescript-eslint.io/rules/no-misused-promises/
