### PR TITLE
fix: disable Rsbuild react plugin chunking strategy for federation examples

### DIFF
--- a/rsbuild/module-federation-enhanced/consumer/rsbuild.config.ts
+++ b/rsbuild/module-federation-enhanced/consumer/rsbuild.config.ts
@@ -19,5 +19,9 @@ export default defineConfig({
       ]);
     },
   },
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact({
+      splitChunks: { react: false, router: false },
+    }),
+  ],
 });

--- a/rsbuild/module-federation-enhanced/provider/rsbuild.config.ts
+++ b/rsbuild/module-federation-enhanced/provider/rsbuild.config.ts
@@ -25,5 +25,9 @@ export default defineConfig({
       ]);
     },
   },
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact({
+      splitChunks: { react: false, router: false },
+    }),
+  ],
 });

--- a/rsbuild/module-federation/host/rsbuild.config.ts
+++ b/rsbuild/module-federation/host/rsbuild.config.ts
@@ -3,7 +3,11 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { mfConfig } from './module-federation.config';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact({
+      splitChunks: { react: false, router: false },
+    }),
+  ],
   server: {
     port: 3000,
   },

--- a/rsbuild/module-federation/remote/rsbuild.config.ts
+++ b/rsbuild/module-federation/remote/rsbuild.config.ts
@@ -3,7 +3,11 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { mfConfig } from './module-federation.config';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact({
+      splitChunks: { react: false, router: false },
+    }),
+  ],
   server: {
     port: 3002,
   },


### PR DESCRIPTION
Disable the react plugin auto chunking strategy in the react example to see the benefits of the module federation sharing option that is configured.

This should be done, otherwise the example does configure a sharing strategy that never has an effect within the federation.