### PR TITLE
feat: add Rsbuild SSR express with manifest example

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,37 @@ importers:
         specifier: ^5.3.0
         version: 5.4.5
 
+  rsbuild/ssr-express-with-manifest:
+    dependencies:
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@rsbuild/core':
+        specifier: 1.1.0
+        version: 1.1.0
+      '@rsbuild/plugin-react':
+        specifier: 1.0.6
+        version: 1.0.6(@rsbuild/core@1.1.0)
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.1
+      express:
+        specifier: ^4.19.2
+        version: 4.19.2
+      typescript:
+        specifier: ^5.3.0
+        version: 5.4.5
+
   rsbuild/styled-components:
     dependencies:
       react:
@@ -6114,6 +6145,11 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
+  '@rsbuild/core@1.1.0':
+    resolution: {integrity: sha512-SyQlJjWgR1VwLt4nuiY0g6L9INv2koH232TeDZuopvNgbRytskD3kJ8bbGWBBXsQjZjtqBEh5ishqf8CIfF8dQ==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+
   '@rsbuild/monorepo-utils@0.5.1':
     resolution: {integrity: sha512-WcdTU0TCCpw1UPn0cIzID3O+/L51G+oWVN3f5kZg4OBKVtpFNptcoDhkG5T9lWCO40r/yyETt0rEbrXdMOzEpg==}
     deprecated: deprecated
@@ -6205,6 +6241,11 @@ packages:
     resolution: {integrity: sha512-c9TyoM+y8tJkmPAfnqC0u8FxuOxCXIjdGhYeAFUniVJrBEwZfJ+O/SvzqjbCtPF+3AhWJAYwDdecq0GhDN2FmQ==}
     peerDependencies:
       '@rsbuild/core': ^1.0.1-beta.16
+
+  '@rsbuild/plugin-react@1.0.6':
+    resolution: {integrity: sha512-k2VS7nvNm74DlVQROK+w+Ua1j60n3qSnVFva8zjmj6uakLCxxp85aRwfEHzaVP/YdDLffweypROuQPYvTZ57ew==}
+    peerDependencies:
+      '@rsbuild/core': 1.x
 
   '@rsbuild/plugin-react@1.0.7':
     resolution: {integrity: sha512-t7T/GqDwodusTAnxGpqVRnQ/G+HYh98zk71qIg19WkjVJJGv57AC1Ppx0/6zzbZAbxU60bfK8TeEEXjhXCdSxA==}
@@ -9510,6 +9551,9 @@ packages:
 
   core-js@3.38.1:
     resolution: {integrity: sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==}
+
+  core-js@3.39.0:
+    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -20384,7 +20428,7 @@ snapshots:
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.4.5)
       jest-validate: 29.7.0
-      jiti: 1.21.0
+      jiti: 1.21.6
       lodash.get: 4.4.2
     transitivePeerDependencies:
       - typescript
@@ -21634,6 +21678,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  '@rsbuild/core@1.1.0':
+    dependencies:
+      '@rspack/core': 1.1.1(@swc/helpers@0.5.13)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.13
+      core-js: 3.39.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   '@rsbuild/monorepo-utils@0.5.1(@swc/helpers@0.5.3)':
     dependencies:
       '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
@@ -21811,6 +21864,12 @@ snapshots:
   '@rsbuild/plugin-react@1.0.1-beta.16(@rsbuild/core@1.0.1-beta.16)':
     dependencies:
       '@rsbuild/core': 1.0.1-beta.16
+      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
+      react-refresh: 0.14.2
+
+  '@rsbuild/plugin-react@1.0.6(@rsbuild/core@1.1.0)':
+    dependencies:
+      '@rsbuild/core': 1.1.0
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
 
@@ -27131,6 +27190,8 @@ snapshots:
   core-js@3.36.1: {}
 
   core-js@3.38.1: {}
+
+  core-js@3.39.0: {}
 
   core-util-is@1.0.3: {}
 

--- a/rsbuild/ssr-express-with-manifest/.gitignore
+++ b/rsbuild/ssr-express-with-manifest/.gitignore
@@ -1,0 +1,13 @@
+# Local
+.DS_Store
+*.local
+*.log*
+
+# Dist
+node_modules
+dist/
+
+# IDE
+.vscode/*
+!.vscode/extensions.json
+.idea

--- a/rsbuild/ssr-express-with-manifest/README.md
+++ b/rsbuild/ssr-express-with-manifest/README.md
@@ -1,0 +1,29 @@
+# Rsbuild Project
+
+## Setup
+
+Install the dependencies:
+
+```bash
+pnpm install
+```
+
+## Get Started
+
+Start the dev server:
+
+```bash
+pnpm dev
+```
+
+Build the app for production:
+
+```bash
+pnpm build
+```
+
+Preview the production build locally:
+
+```bash
+pnpm preview
+```

--- a/rsbuild/ssr-express-with-manifest/package.json
+++ b/rsbuild/ssr-express-with-manifest/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rsbuild-ssr-express-with-manifest",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "node ./server.mjs",
+    "preview": "node ./prod-server.mjs"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "1.1.0",
+    "@rsbuild/plugin-react": "1.0.6",
+    "@types/express": "^4.17.21",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "express": "^4.19.2",
+    "typescript": "^5.3.0"
+  }
+}

--- a/rsbuild/ssr-express-with-manifest/prod-server.mjs
+++ b/rsbuild/ssr-express-with-manifest/prod-server.mjs
@@ -1,0 +1,50 @@
+import express from "express";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+
+const templateHtml = fs.readFileSync('./template.html', 'utf-8');
+
+const serverRender = (_req, res) => {
+  const remotesPath = path.join(process.cwd(), `./dist/server/index.js`);
+
+  const importedApp = require(remotesPath);
+
+  const markup = importedApp.render();
+
+  const { entries } = JSON.parse(fs.readFileSync('./dist/manifest.json', 'utf-8'));
+
+  const { js, css } = entries['index'].initial;
+
+  const scriptTags = js.map(file => `<script src="${file}" defer></script>`).join('\n');
+  const styleTags = css.map(file => `<link rel="stylesheet" href="${file}">`).join('\n');  
+
+  const html = templateHtml.replace("<!--app-content-->", markup).replace('<!--app-head-->', `${scriptTags}\n${styleTags}`);
+
+  res.status(200).set({ "Content-Type": "text/html" }).send(html);
+};
+
+const port = process.env.PORT || 3000;
+
+export async function preview() {
+  const app = express();
+
+  app.get("/", (req, res, next) => {
+    try {
+      serverRender(req, res, next);
+    } catch (err) {
+      console.error("SSR render error, downgrade to CSR...\n", err);
+      next();
+    }
+  });
+
+  app.use(express.static("dist"));
+
+  app.listen(port, () => {
+    console.log(`Server started at http://localhost:${port}`);
+  });
+}
+
+preview(process.cwd());

--- a/rsbuild/ssr-express-with-manifest/rsbuild.config.mjs
+++ b/rsbuild/ssr-express-with-manifest/rsbuild.config.mjs
@@ -1,0 +1,40 @@
+import { defineConfig } from "@rsbuild/core";
+import { pluginReact } from "@rsbuild/plugin-react";
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  dev: {
+    writeToDisk: true 
+  },
+  environments: {
+    web: {
+      output: {
+        target: "web",
+      },
+      source: {
+        entry: {
+          index: "./src/index",
+        },
+      },
+      output: {
+        manifest: true,
+      },
+    },
+    ssr: {
+      output: {
+        target: "node",
+        distPath: {
+          root: "dist/server",
+        },
+      },
+      source: {
+        entry: {
+          index: "./src/index.server",
+        },
+      },
+    },
+  },
+  tools: {
+    htmlPlugin: false
+  }
+});

--- a/rsbuild/ssr-express-with-manifest/src/App.css
+++ b/rsbuild/ssr-express-with-manifest/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/rsbuild/ssr-express-with-manifest/src/App.tsx
+++ b/rsbuild/ssr-express-with-manifest/src/App.tsx
@@ -1,0 +1,12 @@
+import './App.css';
+
+const App = () => {
+  return (
+    <div className="content">
+      <h1>Rsbuild with React</h1>
+      <p>Start building amazing things with Rsbuild.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/rsbuild/ssr-express-with-manifest/src/env.d.ts
+++ b/rsbuild/ssr-express-with-manifest/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />

--- a/rsbuild/ssr-express-with-manifest/src/index.server.tsx
+++ b/rsbuild/ssr-express-with-manifest/src/index.server.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import App from './App';
+
+export function render() {
+  return ReactDOMServer.renderToString(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}

--- a/rsbuild/ssr-express-with-manifest/src/index.tsx
+++ b/rsbuild/ssr-express-with-manifest/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.hydrateRoot(
+  document.getElementById('root')!,
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/rsbuild/ssr-express-with-manifest/template.html
+++ b/rsbuild/ssr-express-with-manifest/template.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rsbuild + Express + SSR</title>
+    <!--app-head-->
+  </head>
+  <body>
+    <div id="root"><!--app-content--></div>
+  </body>
+</html>

--- a/rsbuild/ssr-express-with-manifest/tsconfig.json
+++ b/rsbuild/ssr-express-with-manifest/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
In some cases, the user's html is provided on the server side, and the manifest of script and link needs to be obtained and injected into the html. Grouped manifests can be easily obtained using the [output.manifest](https://rsbuild.dev/config/output/manifest) configuration.

```ts
  const { entries } = JSON.parse(fs.readFileSync('./dist/manifest.json', 'utf-8'));

  const { js, css } = entries['index'].initial;

  const scriptTags = js.map(file => `<script src="${file}" defer></script>`).join('\n');
  const styleTags = css.map(file => `<link rel="stylesheet" href="${file}">`).join('\n');  

  const html = templateHtml.replace('<!--app-head-->', `${scriptTags}\n${styleTags}`);
```