### PR TITLE
chore: enhance ssr manifest example

### DIFF
--- a/rsbuild/ssr-express-with-manifest/rsbuild.config.mjs
+++ b/rsbuild/ssr-express-with-manifest/rsbuild.config.mjs
@@ -3,9 +3,6 @@ import { pluginReact } from "@rsbuild/plugin-react";
 
 export default defineConfig({
   plugins: [pluginReact()],
-  dev: {
-    writeToDisk: true 
-  },
   environments: {
     web: {
       output: {


### PR DESCRIPTION
Starting with rsbuild 1.1.7, manifest is always write to disk, `writeToDisk` is not required.