### PR TITLE
fix: missing typescript dep in basic-ts-config

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,6 +1043,9 @@ importers:
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.10.4(@swc/helpers@0.5.15))(@types/node@22.10.5)(typescript@5.7.2)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.2
 
   rspack/builtin-swc-loader:
     dependencies:

--- a/rspack/basic-ts-config/package.json
+++ b/rspack/basic-ts-config/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@rspack/cli": "1.2.0-alpha.0",
     "@rspack/core": "1.2.0-alpha.0",
-    "ts-node": "10.9.2"
+    "ts-node": "10.9.2",
+    "typescript": "^5.7.2"
   }
 }


### PR DESCRIPTION
Fix https://github.com/web-infra-dev/rspack/actions/runs/12646686870/job/35238282060