### PR TITLE
chore: prefer to use named import

### DIFF
--- a/rsdoctor/rspack/rspack.config.js
+++ b/rsdoctor/rspack/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
 const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
 

--- a/rspack/cra-ts/rspack.config.js
+++ b/rspack/cra-ts/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/cra/rspack.config.js
+++ b/rspack/cra/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/css-parser-generator-options/rspack.config.js
+++ b/rspack/css-parser-generator-options/rspack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/dll-reference/rspack.config.js
+++ b/rspack/dll-reference/rspack.config.js
@@ -1,5 +1,4 @@
-
-const rspack = require('@rspack/core')
+const { rspack } = require('@rspack/core');
 const path = require('node:path');
 
 /** @type {import('@rspack/cli').Configuration} */
@@ -9,7 +8,7 @@ const config = {
     path: path.resolve(__dirname, 'dist'),
   },
   resolve: {
-    extensions: ['...', '.ts', '.tsx', '.js', '.jsx']
+    extensions: ['...', '.ts', '.tsx', '.js', '.jsx'],
   },
   plugins: [
     new rspack.DllReferencePlugin({
@@ -19,10 +18,10 @@ const config = {
     new rspack.DllReferencePlugin({
       manifest: path.resolve(__dirname, '../dll/dist/beta.manifest.json'),
       scope: 'beta',
-      extensions: [".js", ".jsx", '.ts', '.tsx']
+      extensions: ['.js', '.jsx', '.ts', '.tsx'],
     }),
   ],
-  mode: 'development'
-}
+  mode: 'development',
+};
 
-module.exports = config; 
+module.exports = config;

--- a/rspack/dll/rspack.config.js
+++ b/rspack/dll/rspack.config.js
@@ -1,5 +1,4 @@
-
-const rspack = require('@rspack/core')
+const { rspack } = require('@rspack/core');
 const path = require('node:path');
 
 /** @type {import('@rspack/cli').Configuration} */
@@ -8,20 +7,20 @@ const config = {
     extensions: ['...', '.ts', '.tsx', '.js', '.jsx'],
   },
   entry: {
-    alpha: ["./alpha", "./a", "lodash"],
-    beta: ["./beta", "./b", "./c"],
+    alpha: ['./alpha', './a', 'lodash'],
+    beta: ['./beta', './b', './c'],
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: '[name].dll.js',
-    library: '[name]_dll_lib'
+    library: '[name]_dll_lib',
   },
   plugins: [
     new rspack.DllPlugin({
-      path: path.join(__dirname, "dist", "[name].manifest.json"),
+      path: path.join(__dirname, 'dist', '[name].manifest.json'),
       name: '[name]_dll_lib',
-    })
-  ]
-}
+    }),
+  ],
+};
 
-module.exports = config; 
+module.exports = config;

--- a/rspack/emotion/rspack.config.js
+++ b/rspack/emotion/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/extract-license/rspack.config.js
+++ b/rspack/extract-license/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   context: __dirname,

--- a/rspack/hooks/after-resolve/rspack.config.js
+++ b/rspack/hooks/after-resolve/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: './src/index.js',

--- a/rspack/lightingcss-loader/rspack.config.js
+++ b/rspack/lightingcss-loader/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: './src/index.js',

--- a/rspack/minify-test/rspack.config.js
+++ b/rspack/minify-test/rspack.config.js
@@ -1,4 +1,5 @@
-const rspack = require('../../packages/rspack');
+const { rspack } = require('../../packages/rspack');
+
 /**
  * @type {import("@rspack/core").Configuration}
  */

--- a/rspack/module-federation-interop/rspack-mf-v1.5/rspack.config.js
+++ b/rspack/module-federation-interop/rspack-mf-v1.5/rspack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const containerName = 'Rspack_MF_v1_5';

--- a/rspack/module-federation-interop/rspack-mf-v1/rspack.config.js
+++ b/rspack/module-federation-interop/rspack-mf-v1/rspack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 const containerName = 'Rspack_MF_v1';

--- a/rspack/module-federation-v1.5/app/rspack.config.js
+++ b/rspack/module-federation-v1.5/app/rspack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/rspack/module-federation-v1.5/lib1/rspack.config.js
+++ b/rspack/module-federation-v1.5/lib1/rspack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/rspack/module-federation-v1.5/lib2/rspack.config.js
+++ b/rspack/module-federation-v1.5/lib2/rspack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/rspack/module-federation-v1/app/rspack.config.js
+++ b/rspack/module-federation-v1/app/rspack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/rspack/module-federation-v1/lib1/rspack.config.js
+++ b/rspack/module-federation-v1/lib1/rspack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/rspack/module-federation-v1/lib2/rspack.config.js
+++ b/rspack/module-federation-v1/lib2/rspack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/rspack/monaco-editor-js/rspack.config.js
+++ b/rspack/monaco-editor-js/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 
 module.exports = {

--- a/rspack/monaco-editor-ts-react/rspack.config.js
+++ b/rspack/monaco-editor-ts-react/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 
 module.exports = {

--- a/rspack/monaco-editor-webpack-plugin/rspack.config.js
+++ b/rspack/monaco-editor-webpack-plugin/rspack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 module.exports = {
   entry: {

--- a/rspack/multi-entry/rspack.config.js
+++ b/rspack/multi-entry/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/nestjs/rspack.config.js
+++ b/rspack/nestjs/rspack.config.js
@@ -1,5 +1,5 @@
 const { RunScriptWebpackPlugin } = require('run-script-webpack-plugin');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/node-globals-shim/rspack.config.js
+++ b/rspack/node-globals-shim/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/node-polyfill/rspack.config.js
+++ b/rspack/node-polyfill/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/perfsee/rspack.config.js
+++ b/rspack/perfsee/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { PerfseePlugin } = require('@perfsee/webpack');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/polyfill/rspack.config.js
+++ b/rspack/polyfill/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/postcss-loader/rspack.config.js
+++ b/rspack/postcss-loader/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   context: __dirname,

--- a/rspack/preact-refresh/rspack.config.js
+++ b/rspack/preact-refresh/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const PreactRefreshPlugin = require('@rspack/plugin-preact-refresh');
 const dev = process.env.NODE_ENV === 'development';
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/preact/rspack.config.js
+++ b/rspack/preact/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const dev = process.env.NODE_ENV === 'development';
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/proxy/rspack.config.js
+++ b/rspack/proxy/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 module.exports = (env, argv) => {
   console.log('env:', env, argv);

--- a/rspack/react-compiler-babel-ts/rspack.config.js
+++ b/rspack/react-compiler-babel-ts/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/react-compiler-babel/rspack.config.js
+++ b/rspack/react-compiler-babel/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/react-refresh-babel-loader/rspack.config.js
+++ b/rspack/react-refresh-babel-loader/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
 
 const isProduction = process.env.NODE_ENV === 'production';

--- a/rspack/react-refresh/rspack.config.js
+++ b/rspack/react-refresh/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const ReactRefreshPlugin = require('@rspack/plugin-react-refresh');
 
 const isProduction = process.env.NODE_ENV === 'production';

--- a/rspack/react-with-extract-css/rspack.config.js
+++ b/rspack/react-with-extract-css/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/react-with-less/rspack.config.js
+++ b/rspack/react-with-less/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/react-with-sass/rspack.config.js
+++ b/rspack/react-with-sass/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/react/rspack.config.js
+++ b/rspack/react/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/sentry/rspack.config.js
+++ b/rspack/sentry/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {

--- a/rspack/solid/rspack.config.js
+++ b/rspack/solid/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   context: __dirname,

--- a/rspack/source-map-with-vscode-debugging/rspack.config.js
+++ b/rspack/source-map-with-vscode-debugging/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/stats/rspack.config.js
+++ b/rspack/stats/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 class StatsPrinterTestPlugin {
   apply(compiler) {
     compiler.hooks.compilation.tap('StatsPrinterTestPlugin', (compilation) => {

--- a/rspack/styled-components/rspack.config.js
+++ b/rspack/styled-components/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/svgr/rspack.config.js
+++ b/rspack/svgr/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/tailwind-jit/rspack.config.js
+++ b/rspack/tailwind-jit/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   context: __dirname,

--- a/rspack/tailwind/rspack.config.js
+++ b/rspack/tailwind/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /**
  * @type {import('@rspack/cli').Configuration}
  */

--- a/rspack/terser-webpack-plugin/rspack.config.js
+++ b/rspack/terser-webpack-plugin/rspack.config.js
@@ -1,7 +1,7 @@
 const { defineConfig } = require('@rspack/cli');
 const TerserPlugin = require('terser-webpack-plugin');
 const { StatsWriterPlugin } = require('webpack-stats-plugin');
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 
 module.exports = defineConfig({
   plugins: [new StatsWriterPlugin()],

--- a/rspack/treeshaking-transform-imports/rspack.config.js
+++ b/rspack/treeshaking-transform-imports/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/core').Configuration} */
 const config = {
   context: __dirname,

--- a/rspack/vue/rspack.config.js
+++ b/rspack/vue/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { VueLoaderPlugin } = require('vue-loader');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/vue2-ts/rspack.config.js
+++ b/rspack/vue2-ts/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { VueLoaderPlugin } = require('vue-loader');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/vue2/rspack.config.js
+++ b/rspack/vue2/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { VueLoaderPlugin } = require('vue-loader');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/vue3-jsx/rspack.config.js
+++ b/rspack/vue3-jsx/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   context: __dirname,

--- a/rspack/vue3-tsx/rspack.config.js
+++ b/rspack/vue3-tsx/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { VueLoaderPlugin } = require('vue-loader');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/vue3-vanilla/rspack.config.js
+++ b/rspack/vue3-vanilla/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { VueLoaderPlugin } = require('vue-loader');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/wasm-simple/rspack.config.js
+++ b/rspack/wasm-simple/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   entry: {

--- a/rspack/workbox-webpack-plugin/rspack.config.js
+++ b/rspack/workbox-webpack-plugin/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const { GenerateSW } = require('workbox-webpack-plugin');
 
 /** @type {import('@rspack/cli').Configuration} */

--- a/rspack/worker/rspack.config.js
+++ b/rspack/worker/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 const path = require('path');
 
 module.exports = {

--- a/rspack/worklet/rspack.config.js
+++ b/rspack/worklet/rspack.config.js
@@ -1,4 +1,4 @@
-const rspack = require('@rspack/core');
+const { rspack } = require('@rspack/core');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
   context: __dirname,


### PR DESCRIPTION
We prefer to use named import to import/require `rspack`.