### PR TITLE
feat: add rsbuild import asset as string example

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,31 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
 
+  rsbuild/query-raw:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
+    devDependencies:
+      '@rsbuild/core':
+        specifier: 1.2.3
+        version: 1.2.3
+      '@rsbuild/plugin-react':
+        specifier: ^1.1.0
+        version: 1.1.0(@rsbuild/core@1.2.3)
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.0.8
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.0.3(@types/react@19.0.8)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
+
   rsbuild/react:
     dependencies:
       react:
@@ -18991,7 +19016,7 @@ snapshots:
 
   babel-walk@3.0.0-canary-5:
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.26.7
     optional: true
 
   bail@2.0.2: {}
@@ -19500,8 +19525,8 @@ snapshots:
 
   constantinople@4.0.1:
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
     optional: true
 
   constants-browserify@1.0.0: {}
@@ -27384,8 +27409,8 @@ snapshots:
 
   with@7.0.2:
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
       assert-never: 1.2.1
       babel-walk: 3.0.0-canary-5
     optional: true

--- a/rsbuild/query-raw/.gitignore
+++ b/rsbuild/query-raw/.gitignore
@@ -1,0 +1,13 @@
+# Local
+.DS_Store
+*.local
+*.log*
+
+# Dist
+node_modules
+dist/
+
+# IDE
+.vscode/*
+!.vscode/extensions.json
+.idea

--- a/rsbuild/query-raw/README.md
+++ b/rsbuild/query-raw/README.md
@@ -1,0 +1,29 @@
+# Rsbuild Project
+
+## Setup
+
+Install the dependencies:
+
+```bash
+pnpm install
+```
+
+## Get Started
+
+Start the dev server:
+
+```bash
+pnpm dev
+```
+
+Build the app for production:
+
+```bash
+pnpm build
+```
+
+Preview the production build locally:
+
+```bash
+pnpm preview
+```

--- a/rsbuild/query-raw/package.json
+++ b/rsbuild/query-raw/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rsbuild-query-raw",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "rsbuild build",
+    "dev": "rsbuild dev --open",
+    "preview": "rsbuild preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "1.2.3",
+    "@rsbuild/plugin-react": "^1.1.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "typescript": "^5.7.3"
+  }
+}

--- a/rsbuild/query-raw/rsbuild.config.ts
+++ b/rsbuild/query-raw/rsbuild.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  tools: {
+    rspack: (config, { rspack }) => {
+      config.module?.rules?.push({
+        resourceQuery: /raw/,
+        type: 'asset/source',
+      });
+      config.plugins?.push(
+        new rspack.NormalModuleReplacementPlugin(/\?raw$/, (resource) => {
+          resource.request = '!' + resource.request;
+        }),
+      );
+    },
+  },
+});

--- a/rsbuild/query-raw/src/App.css
+++ b/rsbuild/query-raw/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/rsbuild/query-raw/src/App.tsx
+++ b/rsbuild/query-raw/src/App.tsx
@@ -1,0 +1,16 @@
+import cssStr from './App.css?raw';
+import jsonStr from '../package.json?raw';
+
+console.log('cssStr', cssStr);
+console.log('jsonStr', jsonStr);
+
+const App = () => {
+  return (
+    <div className="content">
+      <h1>Rsbuild with React</h1>
+      <p>Start building amazing things with Rsbuild.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/rsbuild/query-raw/src/env.d.ts
+++ b/rsbuild/query-raw/src/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="@rsbuild/core/types" />
+
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/rsbuild/query-raw/src/index.tsx
+++ b/rsbuild/query-raw/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/rsbuild/query-raw/tsconfig.json
+++ b/rsbuild/query-raw/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Add Rsbuild import asset as string example, supports importing assets as string via `?raw` suffix.

```ts
import cssStr from './App.css?raw';
import jsonStr from '../package.json?raw';

console.log('cssStr', cssStr); // output raw string
console.log('jsonStr', jsonStr);  // output raw string
```

More context: https://github.com/web-infra-dev/rsbuild/issues/3435