### PR TITLE
fix: reactRefreshOptions exclude must contain node_modules

### DIFF
--- a/rsbuild/vanilla-extract/rsbuild.config.ts
+++ b/rsbuild/vanilla-extract/rsbuild.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [
     pluginReact({
       reactRefreshOptions: {
-        exclude: [/\.css\.ts$/],
+        exclude: [/node_modules/, /\.css\.ts$/],
       },
     }),
   ],


### PR DESCRIPTION
Fixes example missing exclude `node_modules` in react refresh options which causes in my app error in dev mode (in production build everyting is fine)
```
drune@MBA my-rsbuild-app % npm run dev

> my-rsbuild-app@1.0.0 dev
> rsbuild dev --open

  Rsbuild v1.2.11

  ➜ Local:    http://localhost:3000/
  ➜ Network:  http://192.168.1.64:3000/
  ➜ press h + enter to show shortcuts

start   Building...
/Users/drune/Developer/github.com/AdmiralDS/my-rsbuild-app/src/components/Button/button.css.ts:60
  var maybeModule = __webpack_require__.c[moduleId];
                                         ^

TypeError: Cannot read properties of undefined (reading './node_modules/@admiral-ds/web/dist/chunks/vars.css-DQNm5B2I.js')
    at Object.getModuleExports (/Users/drune/Developer/github.com/AdmiralDS/my-rsbuild-app/src/components/Button/button.css.ts:60:42)
    at Object.refresh (/Users/drune/Developer/github.com/AdmiralDS/my-rsbuild-app/src/components/Button/button.css.ts:12:39)
    at /Users/drune/Developer/github.com/AdmiralDS/my-rsbuild-app/src/components/Button/button.css.ts:714:25

Node.js v22.14.0
```